### PR TITLE
🔥 Archive logs from deleted ProcessModels

### DIFF
--- a/logging.contracts/package.json
+++ b/logging.contracts/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"
   },

--- a/logging.contracts/package.json
+++ b/logging.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging_api_contracts",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha.1",
   "description": "the api-package for process-engine logging",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/logging.contracts/package.json
+++ b/logging.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging_api_contracts",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "the api-package for process-engine logging",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/logging.contracts/package.json
+++ b/logging.contracts/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"
   },

--- a/logging.contracts/src/ilogging_api.ts
+++ b/logging.contracts/src/ilogging_api.ts
@@ -33,12 +33,14 @@ export interface ILoggingApi {
    * @param timestamp         Optional: The timestamp to use for the log entry.
    *                          Defaults to "now".
    */
-  writeLogForProcessModel(correlationId: string,
+  writeLogForProcessModel(
+    correlationId: string,
     processModelId: string,
     processInstanceId: string,
     logLevel: LogLevel,
     message: string,
-    timestamp?: Date): Promise<void>;
+    timestamp?: Date,
+  ): Promise<void>;
 
   /**
    * Writes a log entry for a specific FlowNode of a ProcessModel within a
@@ -58,12 +60,25 @@ export interface ILoggingApi {
    * @param timestamp          Optional: The timestamp to use for the log entry.
    *                           Defaults to "now".
    */
-  writeLogForFlowNode(correlationId: string,
+  writeLogForFlowNode(
+    correlationId: string,
     processModelId: string,
     processInstanceId: string,
     flowNodeInstanceId: string,
     flowNodeId: string,
     logLevel: LogLevel,
     message: string,
-    timestamp?: Date): Promise<void>;
+    timestamp?: Date,
+  ): Promise<void>;
+
+  /**
+   * Places all logs for the given ProcessModel into the "archive" folder.
+   * Essentially, this is pretty much like "deleting" the logs, as they will no longer be available.
+   *
+   * However, since logs are somewhat sensitive, they will not be deleted, but archived.
+   *
+   * @param identity       The identity of the requesting user.
+   * @param processModelId The ID of the ProcessModel whose logs are to be archived.
+   */
+  archiveProcessModelLogs(identity: IIdentity, processModelId: string): Promise<void>;
 }

--- a/logging.contracts/src/ilogging_repository.ts
+++ b/logging.contracts/src/ilogging_repository.ts
@@ -30,12 +30,14 @@ export interface ILoggingRepository {
    * @param timestamp         Optional: The timestamp to use for the log entry.
    *                          Defaults to "now".
    */
-  writeLogForProcessModel(correlationId: string,
+  writeLogForProcessModel(
+    correlationId: string,
     processModelId: string,
     processInstanceId: string,
     logLevel: LogLevel,
     message: string,
-    timestamp?: Date): Promise<void>;
+    timestamp?: Date,
+  ): Promise<void>;
 
   /**
    * Writes a log entry for a specific FlowNode of a ProcessModel within a
@@ -55,12 +57,24 @@ export interface ILoggingRepository {
    * @param timestamp          Optional: The timestamp to use for the log entry.
    *                           Defaults to "now".
    */
-  writeLogForFlowNode(correlationId: string,
+  writeLogForFlowNode(
+    correlationId: string,
     processModelId: string,
     processInstanceId: string,
     flowNodeInstanceId: string,
     flowNodeId: string,
     logLevel: LogLevel,
     message: string,
-    timestamp?: Date): Promise<void>;
+    timestamp?: Date,
+  ): Promise<void>;
+
+  /**
+   * Places all logs for the given ProcessModel into the "archive" folder.
+   * Essentially, this is pretty much like "deleting" the logs, as they will no longer be available.
+   *
+   * However, since logs are somewhat sensitive, they will not be deleted, but archived.
+   *
+   * @param processModelId
+   */
+  archiveProcessModelLogs(processModelId: string): Promise<void>;
 }

--- a/logging.contracts/src/ilogging_repository_config.ts
+++ b/logging.contracts/src/ilogging_repository_config.ts
@@ -1,0 +1,5 @@
+/* eslint-disable @typescript-eslint/camelcase */
+export interface ILoggingRepositoryConfig {
+  output_path: string;
+  archive_path?: string; // If not provided "<output_path>/archive" will be used
+}

--- a/logging.contracts/src/index.ts
+++ b/logging.contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from './ilogging_api';
+export * from './ilogging_repository_config';
 export * from './ilogging_repository';
 export * from './log_entry';
 export * from './log_level';

--- a/logging.repository.file_system/package.json
+++ b/logging.repository.file_system/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/logging.repository.file_system/package.json
+++ b/logging.repository.file_system/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/logging.repository.file_system/package.json
+++ b/logging.repository.file_system/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
-    "@process-engine/logging_api_contracts": "1.1.0",
+    "@process-engine/logging_api_contracts": "feature~implement_log_archival",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/logging.repository.file_system/package.json
+++ b/logging.repository.file_system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging.repository.file_system",
-  "version": "1.3.1",
+  "version": "2.0.0-alpha.1",
   "description": "Contains the file-system repository for the Metrics API. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
-    "@process-engine/logging_api_contracts": "feature~implement_log_archival",
+    "@process-engine/logging_api_contracts": "2.0.0-alpha.1",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/logging.repository.file_system/src/adapter/file_system_adapter.ts
+++ b/logging.repository.file_system/src/adapter/file_system_adapter.ts
@@ -81,9 +81,6 @@ export function readAndParseFile(filePath: string): Array<LogEntry> {
 
 export async function moveLogFileToArchive(fileToMove: string): Promise<void> {
 
-  const archiveFolderPath = path.resolve(this.config.output_path, 'archive');
-  await ensureDirectoryExists(archiveFolderPath);
-
   const timeTagForArchivedFile = moment().toISOString();
 
   const fileInfo = path.parse(fileToMove);

--- a/logging.repository.file_system/src/adapter/file_system_adapter.ts
+++ b/logging.repository.file_system/src/adapter/file_system_adapter.ts
@@ -83,7 +83,7 @@ export async function moveLogFileToArchive(archiveFolderPath, fileToMove): Promi
 
   const timeTagForArchivedFile = moment()
     .toISOString()
-    .replace(/\:/g, '_')
+    .replace(/:/g, '_')
     .replace(/\./g, '_');
 
   const sourceFileInfo = path.parse(fileToMove);

--- a/logging.repository.file_system/src/adapter/file_system_adapter.ts
+++ b/logging.repository.file_system/src/adapter/file_system_adapter.ts
@@ -74,7 +74,8 @@ export function readAndParseFile(filePath: string): Array<LogEntry> {
     return isNotEmpty && isNotAComment;
   });
 
-  const logEntries = logEntriesFiltered.map(parseLogEntry);
+  const convertedLogs = logEntriesFiltered.map(parseLogEntry);
+  const logEntries = convertedLogs.filter((entry): boolean => entry !== undefined);
 
   return logEntries;
 }

--- a/logging.repository.file_system/src/adapter/file_system_adapter.ts
+++ b/logging.repository.file_system/src/adapter/file_system_adapter.ts
@@ -79,13 +79,19 @@ export function readAndParseFile(filePath: string): Array<LogEntry> {
   return logEntries;
 }
 
-export async function moveLogFileToArchive(fileToMove: string): Promise<void> {
+export async function moveLogFileToArchive(archiveFolderPath, fileToMove): Promise<void> {
 
-  const timeTagForArchivedFile = moment().toISOString();
+  const timeTagForArchivedFile = moment()
+    .toISOString()
+    .replace(/\:/g, '_')
+    .replace(/\./g, '_');
 
-  const fileInfo = path.parse(fileToMove);
+  const sourceFileInfo = path.parse(fileToMove);
 
-  const archivedFileName = `${fileInfo.name}-${timeTagForArchivedFile}${fileInfo.ext}`;
+  const archivedFileName = `${sourceFileInfo.name}-${timeTagForArchivedFile}${sourceFileInfo.ext}`;
+  const archivedFilePath = path.resolve(archiveFolderPath, archivedFileName);
 
-  fs.renameSync(fileToMove, archivedFileName);
+  await ensureDirectoryExists(archivedFilePath);
+
+  fs.renameSync(fileToMove, archivedFilePath);
 }

--- a/logging.repository.file_system/src/adapter/file_system_adapter.ts
+++ b/logging.repository.file_system/src/adapter/file_system_adapter.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
+import * as moment from 'moment';
 import * as path from 'path';
 
 import {LogEntry} from '@process-engine/logging_api_contracts';
@@ -76,4 +77,18 @@ export function readAndParseFile(filePath: string): Array<LogEntry> {
   const logEntries = logEntriesFiltered.map(parseLogEntry);
 
   return logEntries;
+}
+
+export async function moveLogFileToArchive(fileToMove: string): Promise<void> {
+
+  const archiveFolderPath = path.resolve(this.config.output_path, 'archive');
+  await ensureDirectoryExists(archiveFolderPath);
+
+  const timeTagForArchivedFile = moment().toISOString();
+
+  const fileInfo = path.parse(fileToMove);
+
+  const archivedFileName = `${fileInfo.name}-${timeTagForArchivedFile}${fileInfo.ext}`;
+
+  fs.renameSync(fileToMove, archivedFileName);
 }

--- a/logging.repository.file_system/src/adapter/parser/flow_node_log_parser.ts
+++ b/logging.repository.file_system/src/adapter/parser/flow_node_log_parser.ts
@@ -4,7 +4,12 @@ import {LogEntry, LogLevel} from '@process-engine/logging_api_contracts';
 
 export function parseFlowNodeInstanceLog(logData: Array<string>): LogEntry {
 
-  return parseAsV1(logData);
+  const isV1 = logData[0] === 'FlowNodeInstance';
+  if (isV1) {
+    return parseAsV1(logData);
+  }
+
+  return undefined;
 }
 
 function parseAsV1(logData: Array<string>): LogEntry {

--- a/logging.repository.file_system/src/adapter/parser/process_model_log_parser.ts
+++ b/logging.repository.file_system/src/adapter/parser/process_model_log_parser.ts
@@ -4,7 +4,12 @@ import {LogEntry, LogLevel} from '@process-engine/logging_api_contracts';
 
 export function parseProcessModelLog(logData: Array<string>): LogEntry {
 
-  return parseAsV1(logData);
+  const isV1 = logData[0] === 'ProcessModel';
+  if (isV1) {
+    return parseAsV1(logData);
+  }
+
+  return undefined;
 }
 
 function parseAsV1(logData: Array<string>): LogEntry {

--- a/logging.repository.file_system/src/logging_repository.ts
+++ b/logging.repository.file_system/src/logging_repository.ts
@@ -90,10 +90,11 @@ export class LoggingRepository implements ILoggingRepository {
       return;
     }
 
-    const archiveFolderPath = path.resolve(this.config.output_path, 'archive');
-    await FileSystemAdapter.ensureDirectoryExists(archiveFolderPath);
+    const archiveFolderToUse = this.config.archive_path
+      ? path.resolve(path.normalize(this.config.archive_path))
+      : path.resolve(this.config.output_path, 'archive');
 
-    await FileSystemAdapter.moveLogFileToArchive(processModelId);
+    await FileSystemAdapter.moveLogFileToArchive(archiveFolderToUse, targetFilePath);
   }
 
   private async writeLogEntryToFileSystem(processModelId: string, ...values: Array<string>): Promise<void> {

--- a/logging.repository.file_system/src/logging_repository.ts
+++ b/logging.repository.file_system/src/logging_repository.ts
@@ -89,6 +89,10 @@ export class LoggingRepository implements ILoggingRepository {
     if (processModelHasNoLogs) {
       return;
     }
+
+    const archiveFolderPath = path.resolve(this.config.output_path, 'archive');
+    await FileSystemAdapter.ensureDirectoryExists(archiveFolderPath);
+
     await FileSystemAdapter.moveLogFileToArchive(processModelId);
   }
 

--- a/logging.repository.file_system/src/logging_repository.ts
+++ b/logging.repository.file_system/src/logging_repository.ts
@@ -1,4 +1,9 @@
-import {ILoggingRepository, LogEntry, LogLevel} from '@process-engine/logging_api_contracts';
+import {
+  ILoggingRepository,
+  ILoggingRepositoryConfig,
+  LogEntry,
+  LogLevel,
+} from '@process-engine/logging_api_contracts';
 
 import * as moment from 'moment';
 import * as path from 'path';
@@ -7,7 +12,7 @@ import * as FileSystemAdapter from './adapter';
 
 export class LoggingRepository implements ILoggingRepository {
 
-  public config: any;
+  public config: ILoggingRepositoryConfig;
 
   public async readLogForProcessModel(processModelId: string): Promise<Array<LogEntry>> {
 

--- a/logging.repository.file_system/src/logging_repository.ts
+++ b/logging.repository.file_system/src/logging_repository.ts
@@ -79,6 +79,19 @@ export class LoggingRepository implements ILoggingRepository {
     await this.writeLogEntryToFileSystem(processModelId, ...logEntryValues);
   }
 
+  public async archiveProcessModelLogs(processModelId: string): Promise<void> {
+
+    const fileNameWithExtension = `${processModelId}.log`;
+
+    const targetFilePath = this.buildPath(fileNameWithExtension);
+
+    const processModelHasNoLogs = !FileSystemAdapter.targetExists(targetFilePath);
+    if (processModelHasNoLogs) {
+      return;
+    }
+    await FileSystemAdapter.moveLogFileToArchive(processModelId);
+  }
+
   private async writeLogEntryToFileSystem(processModelId: string, ...values: Array<string>): Promise<void> {
 
     const fileNameWithExtension = `${processModelId}.log`;

--- a/logging.service/package.json
+++ b/logging.service/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/logging.service/package.json
+++ b/logging.service/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/logging.service/package.json
+++ b/logging.service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging_api_core",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Contains all the core components for the logging api. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/logging.service/package.json
+++ b/logging.service/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/logging_api_core#readme",
   "dependencies": {
-    "@process-engine/logging_api_contracts": "1.1.0",
+    "@process-engine/logging_api_contracts": "feature~implement_log_archival",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/logging.service/package.json
+++ b/logging.service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging_api_core",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha.1",
   "description": "Contains all the core components for the logging api. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/logging_api_core#readme",
   "dependencies": {
-    "@process-engine/logging_api_contracts": "feature~implement_log_archival",
+    "@process-engine/logging_api_contracts": "2.0.0-alpha.1",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/logging.service/src/logging_api_service.ts
+++ b/logging.service/src/logging_api_service.ts
@@ -47,4 +47,10 @@ export class LoggingApiService implements ILoggingApi {
       .writeLogForFlowNode(correlationId, processModelId, processInstanceId, flowNodeInstanceId, flowNodeId, logLevel, message, timestamp);
   }
 
+  public async archiveProcessModelLogs(identity: IIdentity, processModelId: string): Promise<void> {
+    await this
+      .loggingRepository
+      .archiveProcessModelLogs(processModelId);
+  }
+
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging_api",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Changes

1. Implement `archiveProcessModelLogs` functionality for each layer
2. Add `LoggingRepositoryConfig` interface for use with the `LoggingRepository`'s config

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/373

PR: #1

## How to test the changes

- Create some logs for a ProcessModel
- Call `archiveProcessModelLogs` with that ProcessModel's ID
- See that the logfile is moved to the `archive` folder
    - Note: If you haven't specified `archive_path` in your repository-config, then the file will be moved to `<output_path>/archive`