### PR TITLE
🐛 Fix process model log parsing

### DIFF
--- a/logging.contracts/package.json
+++ b/logging.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging_api_contracts",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "the api-package for process-engine logging",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/logging.contracts/package.json
+++ b/logging.contracts/package.json
@@ -28,7 +28,7 @@
     "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^12.11.7",
     "eslint": "^6.6.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/logging.contracts/tsconfig.json
+++ b/logging.contracts/tsconfig.json
@@ -7,9 +7,9 @@
     "outDir": "./dist/commonjs",
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2018",
+    "target": "es2019",
     "lib": [
-      "es2018"
+      "es2019"
     ],
     "declaration": true,
     "skipLibCheck": true,

--- a/logging.repository.file_system/package.json
+++ b/logging.repository.file_system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging.repository.file_system",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Contains the file-system repository for the Metrics API. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/logging_api_contracts": "2.0.0",
+    "@process-engine/logging_api_contracts": "2.0.1",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/logging.repository.file_system/package.json
+++ b/logging.repository.file_system/package.json
@@ -30,7 +30,7 @@
     "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^12.11.7",
     "eslint": "^6.6.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/logging.repository.file_system/src/adapter/parser/flow_node_log_parser.ts
+++ b/logging.repository.file_system/src/adapter/parser/flow_node_log_parser.ts
@@ -47,10 +47,10 @@ function parseAsV2(logData: Array<string>): LogEntry {
   logEntry.message = logData[8];
   logEntry.measuredAt = <MetricMeasurementPoint> logData[9];
 
-  const serializedTokenPayload = logData[10].trim();
-  const serializedError = logData[11].trim();
+  const serializedTokenPayload = logData[10]?.trim();
+  const serializedError = logData[11]?.trim();
 
-  const deserializedError = serializedError.length > 1
+  const deserializedError = serializedError?.length > 1
     ? Serializer.deserialize(serializedError)
     : undefined;
 

--- a/logging.repository.file_system/src/adapter/parser/process_model_log_parser.ts
+++ b/logging.repository.file_system/src/adapter/parser/process_model_log_parser.ts
@@ -43,9 +43,9 @@ function parseAsV2(logData: Array<string>): LogEntry {
   logEntry.message = logData[8];
   logEntry.measuredAt = <MetricMeasurementPoint> logData[9];
 
-  const serializedError = logData[11].trim();
+  const serializedError = logData[11]?.trim();
 
-  const deserializedError = serializedError.length > 1
+  const deserializedError = serializedError?.length > 1
     ? Serializer.deserialize(serializedError)
     : undefined;
 

--- a/logging.repository.file_system/tsconfig.json
+++ b/logging.repository.file_system/tsconfig.json
@@ -7,9 +7,9 @@
     "outDir": "./dist/commonjs",
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2018",
+    "target": "es2019",
     "lib": [
-      "es2018"
+      "es2019"
     ],
     "declaration": true,
     "skipLibCheck": true,

--- a/logging.service/package.json
+++ b/logging.service/package.json
@@ -29,7 +29,7 @@
     "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^12.11.7",
     "eslint": "^6.6.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/logging.service/package.json
+++ b/logging.service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/logging_api_core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Contains all the core components for the logging api. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/logging_api_core#readme",
   "dependencies": {
-    "@process-engine/logging_api_contracts": "2.0.0",
+    "@process-engine/logging_api_contracts": "2.0.1",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/logging.service/tsconfig.json
+++ b/logging.service/tsconfig.json
@@ -7,9 +7,9 @@
     "outDir": "./dist/commonjs",
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2018",
+    "target": "es2019",
     "lib": [
-      "es2018"
+      "es2019"
     ],
     "declaration": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Changes

1. Fix an issue that could cause log parsing to fail, if a log entry did not contained an error.
2. Update transpilation target to es2019
3. Use Typescript 3.7

## Issues

PR: #4

## How to test the changes

- Run a number of ProcessInstances that produces varying log entries
- See that requesting them works